### PR TITLE
RELENG-2330 Replace the legacy /repo prefix in the Artifactory URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 	      </snapshots>
 	      <id>forgerock-internal-releases</id>
 	      <name>ForgeRock Release Repository</name>
-	      <url>http://maven.forgerock.org/repo/internal-releases</url>
+	      <url>https://maven.forgerock.org/artifactory/internal-releases</url>
 	    </repository>
 	    <repository>
 	      <snapshots>
@@ -95,7 +95,7 @@
 	      </snapshots>
 	      <id>forgerock-private-releases</id>
 	      <name>ForgeRock Private Release Repository</name>
-	      <url>http://maven.forgerock.org/repo/private-releases</url>
+	      <url>https://maven.forgerock.org/artifactory/private-releases</url>
 	    </repository>
 	    <repository>
 	      <releases>
@@ -106,7 +106,7 @@
 	      </snapshots>
 	      <id>forgerock-internal-snapshots</id>
 	      <name>ForgeRock Snapshot Repository</name>
-	      <url>http://maven.forgerock.org/repo/internal-snapshots</url>
+	      <url>https://maven.forgerock.org/artifactory/internal-snapshots</url>
 	    </repository>
 	    <repository>
 	      <releases>
@@ -117,7 +117,7 @@
 	      </snapshots>
 	      <id>maven.forgerock.org</id>
 	      <name>maven.forgerock.org-openam-dependencies</name>
-	      <url>http://maven.forgerock.org/repo/openam-dependencies</url>
+	      <url>https://maven.forgerock.org/artifactory/openam-dependencies</url>
 	    </repository>
 	    <repository>
 	      <releases>
@@ -128,7 +128,7 @@
 	      </snapshots>
 	      <id>restlet-cache</id>
 	      <name>Restlet Cache Repository</name>
-	      <url>http://maven.forgerock.org/repo/maven.restlet.org</url>
+	      <url>https://maven.forgerock.org/artifactory/maven.restlet.org</url>
 	    </repository>
 	    <repository>
 	      <snapshots>
@@ -159,7 +159,7 @@
 
 		<repository>
 			<id>forgerock-build-dependencies</id>
-			<url>https://maven.forgerock.org/repo/forgerock-openam-6.5.2-dependencies</url>
+			<url>https://maven.forgerock.org/artifactory/forgerock-openam-6.5.2-dependencies</url>
 		</repository>
 
 	  </repositories>


### PR DESCRIPTION
Hi,
The ForgeRock Artifactory instance will soon move to the JFrog.io SaaS.
The URL will remain the same but the /repo prefix won't work anymore.
Thanks,
Bruno Lavit, release manager at ForgeRock